### PR TITLE
Fix mac osx compilation of simu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mtl_compiler
 libvcomp.a
 *.bin
 *.mtl
+dumpbc.c

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ obj/%.o : %.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(SIMU_TARGET): $(SIMU_OBJS)
-	$(CPP) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CPP) -lresolv $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(COMP_TARGET): $(COMP_OBJS)
 	$(CPP) $(LDFLAGS) -o $@ $^ $(LIBS)


### PR DESCRIPTION
Add `-lresolv` to fix:

```
g++ -m32 -o mtl_simu obj/src/simu/linux/main.o obj/src/vm/vaudio.o obj/src/vm/vinterp.o obj/src/vm/vloader.o obj/src/vm/vlog.o obj/src/vm/vmem.o obj/src/vm/vnet.o obj/src/simu/dumpbc.o obj/src/simu/log.o obj/src/simu/properties.o obj/src/simu/linux/simu.o obj/src/simu/linux/simuaudio.o obj/src/simu/linux/simunet.o libvcomp.a -lm
Undefined symbols for architecture i386:
  "_res_9_init", referenced from:
      _udpsend in simunet.o
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```